### PR TITLE
Replace (string) casting with (array) in version::getPrerelease().

### DIFF
--- a/src/vierbergenlars/SemVer/version.php
+++ b/src/vierbergenlars/SemVer/version.php
@@ -75,7 +75,7 @@ class version
      */
     public function getPrerelease()
     {
-        return (string) $this->version->prerelease->valueOf();
+        return (array) $this->version->prerelease->valueOf();
     }
 
     /**

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -234,4 +234,18 @@ class versioningTest extends \UnitTestCase
                 new SemVer\version($version);
             }
         }
+    function testPrerelease()
+    {
+        $t = array(
+            '1.0.0-alpha'=>array('alpha'),
+            '1.0.0-alpha.1'=>array('alpha', '1'),
+            '1.0.0-0.3.7'=>array('0', '3', '7'),
+            '1.0.0-x.7.z.92'=>array('x', '7', 'z', '92'),
+        );
+        foreach($t as $version => $prerelease) {
+            $v=new SemVer\version($version);
+            $this->assertEqual($v->getPrerelease(), $prerelease);
+        }
+    }
+
 }


### PR DESCRIPTION
`version::getPrerelease()` always returns the string 'Array' because of an explicit Array ton string conversion.

The documentation states that `version::getPrerelease()` should return an array, so the `(string)` casting must be a typo or a leftover from previous implementation.
