### PR TITLE
chore: fix return type will change deprecation in PHP 8.1

### DIFF
--- a/src/vierbergenlars/LibJs/JSArray.php
+++ b/src/vierbergenlars/LibJs/JSArray.php
@@ -149,27 +149,31 @@ class JSArray extends JObject implements \ArrayAccess, \Iterator
         }
     }
 
-
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_convert(current($this->array));
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_convert(key($this->array));
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return $this->_convert(next($this->array));
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->array[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if(!$this->offsetExists($offset))
@@ -177,21 +181,25 @@ class JSArray extends JObject implements \ArrayAccess, \Iterator
         return $this->_convert($this->array[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->array[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->array[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return key($this->array) !== null;

--- a/src/vierbergenlars/LibJs/JString.php
+++ b/src/vierbergenlars/LibJs/JString.php
@@ -207,21 +207,25 @@ class JString extends JObject implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->str[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->str[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->str[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \LogicException('Cannot unset a position in a string');


### PR DESCRIPTION
address https://github.com/vierbergenlars/php-semver/pull/61, but without breaking compatibility with previous versions of PHP